### PR TITLE
Fix checkpoint save signature

### DIFF
--- a/portRunner.py
+++ b/portRunner.py
@@ -319,10 +319,10 @@ def writer_thread(csv_path: Path,
 ###############################################################################
 
 
-def save_checkpoint(path: Path, todo: Iterable[Tuple[str, int]], written: int):
+def save_checkpoint(path: Path, todo: Iterable[Tuple[str, int]]):
+    """Persist remaining targets to a JSON checkpoint file."""
     data = {
         "remaining": list(todo),
-        "written_rows": written,
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }
     path.write_text(json.dumps(data, indent=2))

--- a/portRunner.py
+++ b/portRunner.py
@@ -320,7 +320,7 @@ def writer_thread(csv_path: Path,
 
 
 def save_checkpoint(path: Path, todo: Iterable[Tuple[str, int]]):
-    """Persist remaining targets to a JSON checkpoint file."""
+    """Write remaining targets to a checkpoint JSON file."""
     data = {
         "remaining": list(todo),
         "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -329,6 +329,7 @@ def save_checkpoint(path: Path, todo: Iterable[Tuple[str, int]]):
 
 
 def load_checkpoint(path: Path) -> List[Tuple[str, int]]:
+    """Load remaining targets from a checkpoint JSON file."""
     return json.loads(path.read_text())["remaining"]
 
 


### PR DESCRIPTION
## Summary
- fix mismatch in `save_checkpoint` signature

## Testing
- `python -m py_compile portRunner.py sniffer.py`

------
https://chatgpt.com/codex/tasks/task_e_68403b8c25e483219642ea6565f89a04