### PR TITLE
Interleave hosts across ports

### DIFF
--- a/portRunner.py
+++ b/portRunner.py
@@ -477,7 +477,7 @@ def main():
         if not args.dryrun:
             hosts = filter_responsive_hosts(hosts, args.timeout)
         ports = expand_ports(args.port)
-        targets = [(h, p) for h in hosts for p in ports]
+        targets = [(h, p) for p in ports for h in hosts]
         logging.info("generated %d (ip,port) tuples", len(targets))
 
     # Resource guard (posix)


### PR DESCRIPTION
## Summary
- avoid hitting the same IP sequentially by generating the target queue per-port
- compile check

## Testing
- `python -m py_compile portRunner.py`

------
https://chatgpt.com/codex/tasks/task_e_684263c6aabc8321b28c1dab8dee366b